### PR TITLE
Make the datetime picker more coherent by darkening the selected date

### DIFF
--- a/projects/picker/src/sass/picker.scss
+++ b/projects/picker/src/sass/picker.scss
@@ -738,9 +738,15 @@ $owl-missing: yellowgreen !default;
 
   &.isActive {
     border-color: $owl-accent-color;
+    outline: none;
+    background: $owl-light-selected-bg;
+    opacity: 1;
+
+    @include darkTheme(true) {
+      background: $owl-dark-light-selected-bg;
+    }
   }
 
-  &:focus,
   &:hover {
     outline: none;
     background: $owl-light-selected-bg;


### PR DESCRIPTION
# Description

This small style change makes the datetime picker more coherent by darkening the selected reminder date instead of the first focused one. This is a changed requested on the super-productivity repo.

## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/2247

